### PR TITLE
Fix default loader.

### DIFF
--- a/src/react-infinite-scroll.js
+++ b/src/react-infinite-scroll.js
@@ -16,8 +16,7 @@ module.exports = function (React) {
         pageStart: 0,
         hasMore: false,
         loadMore: function () {},
-        threshold: 250,
-        loader: InfiniteScroll._defaultLoader
+        threshold: 250
       };
     },
     componentDidMount: function () {
@@ -29,7 +28,7 @@ module.exports = function (React) {
     },
     render: function () {
       var props = this.props;
-      return React.DOM.div(null, props.children, props.hasMore && props.loader);
+      return React.DOM.div(null, props.children, props.hasMore && (props.loader || InfiniteScroll._defaultLoader));
     },
     scrollListener: function () {
       var el = this.getDOMNode();


### PR DESCRIPTION
I'm using react-infinite-scroll with the latest version of React, and I encountered runtime errors when I first tried to load it.

I assume that React changed the semantics of getDefaultProps at some point and that this change resulted in the issue.
