### PR TITLE
Reset infinite scroll element when re-rendering from parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroll",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "main": "src/react-infinite-scroll.js",
   "scripts": {

--- a/src/react-infinite-scroll.js
+++ b/src/react-infinite-scroll.js
@@ -17,7 +17,7 @@ module.exports = function (React) {
         hasMore: false,
         loadMore: function () {},
         threshold: 250,
-        loader: InfiniteScroll._defaultLoader
+        loader: this._defaultLoader
       };
     },
     componentDidMount: function () {

--- a/src/react-infinite-scroll.js
+++ b/src/react-infinite-scroll.js
@@ -21,7 +21,6 @@ module.exports = function (React) {
       };
     },
     componentDidMount: function () {
-      this.pageLoaded = this.props.pageStart;
       this.attachScrollListener();
     },
     componentDidUpdate: function () {
@@ -38,7 +37,7 @@ module.exports = function (React) {
         this.detachScrollListener();
         // call loadMore after detachScrollListener to allow
         // for non-async loadMore functions
-        this.props.loadMore(this.pageLoaded += 1);
+        this.props.loadMore(this.props.pageStart += 1);
       }
     },
     attachScrollListener: function () {


### PR DESCRIPTION
Works exactly the same as before, except now it resets the count/page if you re-render/update the parent item.

Also fixes an undefined reference.
