### PR TITLE
make component compatible with React v0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install : `npm install react-infinite-scroll`
 
 Then :
 ```javascript
-InfiniteScroll = require('react-infinite-scroll')(React);
+InfiniteScroll = require('react-infinite-scroll')(React, ReactDOM);
 ```
 
 ### Also works with AMD (e.g [RequireJS](http://requirejs.org))

--- a/src/react-infinite-scroll.js
+++ b/src/react-infinite-scroll.js
@@ -5,7 +5,7 @@ function topPosition(domElt) {
   return domElt.offsetTop + topPosition(domElt.offsetParent);
 }
 
-module.exports = function (React) {
+module.exports = function (React, ReactDOM) {
   if (React.addons && React.addons.InfiniteScroll) {
     return React.addons.InfiniteScroll;
   }
@@ -31,7 +31,7 @@ module.exports = function (React) {
       return React.DOM.div(null, props.children, props.hasMore && (props.loader || InfiniteScroll._defaultLoader));
     },
     scrollListener: function () {
-      var el = this.getDOMNode();
+      var el = ReactDOM.findDOMNode(this);
       var scrollTop = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
       if (topPosition(el) + el.offsetHeight - scrollTop - window.innerHeight < Number(this.props.threshold)) {
         this.detachScrollListener();


### PR DESCRIPTION
- this.getDOMNode() is deprecated and the root element has to be searched with ReactDOM.findDOMNode
