### PR TITLE
Update react-infinite-scroll.js

### DIFF
--- a/src/react-infinite-scroll.js
+++ b/src/react-infinite-scroll.js
@@ -24,6 +24,7 @@ module.exports = function (React) {
       this.attachScrollListener();
     },
     componentDidUpdate: function () {
+      this.detachScrollListener();
       this.attachScrollListener();
     },
     render: function () {


### PR DESCRIPTION
'react-infinite-scroll' is a good component. 
But I think there is an issue.

Call the detachScrollListener function only when 'offset' is less than 'threshold' in the scrollListener function.
So when 'hasMore' changes, the detachScrollListener function is not called.
That's why I think the function detachScrollListener should be called in the componentUpdate function as well.